### PR TITLE
Fixes for a couple of bugs

### DIFF
--- a/effect_freeverb.cpp
+++ b/effect_freeverb.cpp
@@ -474,7 +474,7 @@ void AudioEffectFreeverbStereo::update()
 		outputR = sat16(bufout - outputR, 1);
 		if (++allpass4indexR >= sizeof(allpass4bufR)/sizeof(int16_t)) allpass4indexR = 0;
 
-		outblockR->data[i] = sat16(outputL * 30, 0);
+		outblockR->data[i] = sat16(outputR * 30, 0);
 	}
 	transmit(outblockL, 0);
 	transmit(outblockR, 1);

--- a/input_tdm.cpp
+++ b/input_tdm.cpp
@@ -98,8 +98,8 @@ static void memcpy_tdm_rx(uint32_t *dest1, uint32_t *dest2, const uint32_t *src)
 		in1 = *src;
 		in2 = *(src+8);
 		src += 16;
-		*dest1++ = (in1 >> 16) | (in2 & 0xFFFF0000);
-		*dest2++ = (in1 << 16) | (in2 & 0x0000FFFF);
+		*dest1++ = ((in1 >> 16) & 0x0000FFFF) | ((in2 <<  0) & 0xFFFF0000);
+		*dest2++ = ((in1 >>  0) & 0x0000FFFF) | ((in2 << 16) & 0xFFFF0000);	
 	}
 }
 

--- a/input_tdm2.cpp
+++ b/input_tdm2.cpp
@@ -79,8 +79,8 @@ static void memcpy_tdm_rx(uint32_t *dest1, uint32_t *dest2, const uint32_t *src)
 		in1 = *src;
 		in2 = *(src+8);
 		src += 16;
-		*dest1++ = (in1 >> 16) | (in2 & 0xFFFF0000);
-		*dest2++ = (in1 << 16) | (in2 & 0x0000FFFF);
+		*dest1++ = ((in1 >> 16) & 0x0000FFFF) | ((in2 <<  0) & 0xFFFF0000);
+		*dest2++ = ((in1 >>  0) & 0x0000FFFF) | ((in2 << 16) & 0xFFFF0000);	
 	}
 }
 


### PR DESCRIPTION
AudioInputTDM[2] input bug fixes issue #429
Freeverb bug fixes mono output of AudioEffectFreeverbStereo reported in https://forum.pjrc.com/threads/70334-Possible-bug-in-effect_freeverb-cpp-in-the-current-release-of-Teensyduino-(1-56)

Don't give me the credit, I just followed the instructions and did the PR!